### PR TITLE
Add debian-bookworm, ubuntu-kinetic; remove ubuntu-impish

### DIFF
--- a/ci/rebuild-docker-images.py
+++ b/ci/rebuild-docker-images.py
@@ -22,8 +22,8 @@ parser.add_option('--no-push', action="store_true",
 
 registry_base = 'registry.oxen.rocks/lokinet-ci-'
 
-distros = [*(('debian', x) for x in ('sid', 'stable', 'testing', 'bullseye', 'buster')),
-           *(('ubuntu', x) for x in ('rolling', 'lts', 'jammy', 'impish', 'focal', 'bionic'))]
+distros = [*(('debian', x) for x in ('sid', 'stable', 'testing', 'bookworm', 'bullseye', 'buster')),
+           *(('ubuntu', x) for x in ('rolling', 'lts', 'kinetic', 'jammy', 'focal', 'bionic'))]
 
 rebuild_nodejs = False
 


### PR DESCRIPTION
- bookworm (i.e. testing) and kinetic (22.10) are pre-release distro versions
- impish is no longer Ubuntu-supported