### PR TITLE
nodejs: add different arches and different nodejs versions

### DIFF
--- a/rebuild-all.sh
+++ b/rebuild-all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # build ci docker images
-cd ci && ./rebuild-docker-images.py -j $(nproc) && cd -
+cd ci && ./rebuild-docker-images.py -j ${PARALLEL:-$(nproc)} && cd -
 
 # build lokinet docker images
 make -C lokinet


### PR DESCRIPTION
This updates to create nodejs-{14,16,18,lts,current} variants with
/amd64, /arm64v8 and /arm32v7 variants for each.  (Currently current ==
18, and 16 == lts, but these are rolling targets).

Existing use of nodejs image in other build scripts should probably be
replaced with nodejs-lts.