### PR TITLE
Docker sucks

### DIFF
--- a/ci/rebuild-docker-images.py
+++ b/ci/rebuild-docker-images.py
@@ -111,12 +111,12 @@ def build_tag(tag_base, arch, contents, *, manifest_now=False):
     linelock.release()
 
     with tempfile.TemporaryDirectory(dir='.') as dockerdir:
-        with open(dockerdir + '/dockerfile', 'w') as f:
+        with open(dockerdir + '/Dockerfile', 'w') as f:
             f.write(contents)
 
         tag = f'{tag_base}/{arch}'
         print_line(myline,     f"\033[33;1mRebuilding        \033[35;1m{tag}\033[0m")
-        run_or_report('docker', 'build', '--pull', '-f', 'dockerfile', '-t', tag,
+        run_or_report('docker', 'build', '--pull', '-t', tag,
                       *(('--no-cache',) if options.no_cache else ()), '.', myline=myline, cwd=dockerdir)
         if options.no_push:
             print_line(myline, f"\033[33;1mSkip Push         \033[35;1m{tag}\033[0m")

--- a/ci/rebuild-docker-images.py
+++ b/ci/rebuild-docker-images.py
@@ -337,7 +337,7 @@ RUN cd /opt \
     && curl https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.7.8-stable.tar.xz \
         | tar xJv --no-same-owner \
     && ln -s /opt/flutter/bin/flutter /usr/local/bin/ \
-    && flutter upgrade && flutter precache
+    && flutter upgrade --force && flutter precache
 """, manifest_now=True)
 
 


### PR DESCRIPTION
Apparently when you run `docker build` it makes a full copy of cwd into some tmp build path for no good reason, and then later on breaks if anything in the original source directory has changed, which makes it racy as hell (and also a huge waste of time if there is anything substantial currently in the build directory).

This works around docker's garbage design by putting the generated docker files into temp directories and running the build inside that temp directory.

Also includes a fix to the flutter upgrade script, which breaks as is because flutter sucks, too.